### PR TITLE
bug: do not redefine targets in config file.

### DIFF
--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -38,7 +38,10 @@ foreach (_target
          type_expr)
     set(scoped_name "googleapis-c++::${_target}_protos")
     set(imported_name "googleapis_cpp_${_target}_protos")
-    add_library(${scoped_name} IMPORTED INTERFACE)
-    set_target_properties(${scoped_name}
-                          PROPERTIES INTERFACE_LINK_LIBRARIES ${imported_name})
+    if (NOT TARGET ${scoped_name})
+        add_library(${scoped_name} IMPORTED INTERFACE)
+        set_target_properties(${scoped_name}
+                              PROPERTIES INTERFACE_LINK_LIBRARIES
+                              ${imported_name})
+    endif ()
 endforeach ()


### PR DESCRIPTION
If the config file is included twice (via `find_dependency()` or
`find_package()`) some of the targets could get redefined, breaking the
configuration.

This is related to googleapis/google-cloud-cpp#3032.
