### PR TITLE
fix: avoid warnings with newer CMake versions

### DIFF
--- a/cmake/FindgRPC.cmake
+++ b/cmake/FindgRPC.cmake
@@ -68,7 +68,8 @@ find_package(Threads REQUIRED)
 # Load the module to find protobuf with proper targets. Do not use
 # `find_package()` because we (have to) install this module in non-standard
 # locations.
-include(${CMAKE_CURRENT_LIST_DIR}/FindProtobufTargets.cmake)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+find_package(ProtobufTargets)
 
 # The gRPC::grpc_cpp_plugin target is sometimes defined, but without a
 # IMPORTED_LOCATION

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -14,8 +14,9 @@
 # limitations under the License.
 # ~~~
 
-include("${CMAKE_CURRENT_LIST_DIR}/FindProtobufTargets.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/FindgRPC.cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+find_package(ProtobufTargets)
+find_package(gRPC)
 
 include("${CMAKE_CURRENT_LIST_DIR}/googleapis-targets.cmake")
 


### PR DESCRIPTION
I noticed this with CMake 3.17.1, but may have started earlier. Using
`include()` to load a module does not work because the calls to
`find_package_handle_standard_args()` generate a ton of warnings.
Loading the module using `find_package()` works as expected.

Part of the work for googleapis/google-cloud-cpp#3892 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/cpp-cmakefiles/48)
<!-- Reviewable:end -->
