### PR TITLE
chore: bump version numbers after release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(PACKAGE_BUGREPORT "https://github.com/googleapis/google-cloud-cpp/issues")
 project(googleapis-cpp-protos CXX C)
 
 set(GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR 0)
-set(GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR 9)
+set(GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR 10)
 set(GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH 0)
 
 string(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/cpp-cmakefiles/49)
<!-- Reviewable:end -->
