### PR TITLE
chore: update protos to circa 2020-05-17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Give application developers a hook to configure the version and hash
 # downloaded from GitHub.
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
-    "https://github.com/googleapis/googleapis/archive/fea22b1d9f27f86ef355c1d0dba00e0791a08a19.tar.gz"
+    "https://github.com/googleapis/googleapis/archive/abd6b709a5533ba5d0bc435189ffda7f2445cd4b.tar.gz"
 )
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
-    "957ef432cdedbace1621bb023e6d8637ecbaa78856b3fc6e299f9b277ae990ff")
+    "c45d0e135ac7ad54c34546404d5338e4980d0b397f093e1e2cb185ec8813430f")
 
 set(GOOGLEAPIS_CPP_SOURCE
     "${CMAKE_BINARY_DIR}/external/googleapis/src/googleapis_download")


### PR DESCRIPTION
Use the same commit we are using for the Bazel builds in
google-cloud-cpp. AFAICT, there are no significant changes, but it
is good to keep both build systems in sync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/cpp-cmakefiles/50)
<!-- Reviewable:end -->
